### PR TITLE
Add db initialisation before first use

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -1,4 +1,10 @@
 import os
 from Flasktest import app
+from Flasktest.database import init_db
+
+@app.before_first_request
+def init_stuff():
+  init_db()
+
 port = int(os.environ.get('PORT', 5000))
 app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
The app failed to run correctly as the databae tables it was expecting
were not being created on first use. This commit adds a call so that
db tables are created before the app is first used.