### PR TITLE
[#95617860] Add container ID to page title

### DIFF
--- a/Flasktest/templates/layout.html
+++ b/Flasktest/templates/layout.html
@@ -2,7 +2,7 @@
 <title>Flasktest</title>
 <link rel=stylesheet type=text/css href="{{ url_for('static', filename='style.css') }}">
 <div class='page'>
-	<h1>Flasktest</h1>
+	<h1>Flasktest - {{ hostname }}</h1>
 	<div class='metanav'>
 	{%if not session.logged_in %}
 		<a href="{{ url_for('login') }}">log in </a>

--- a/Flasktest/views.py
+++ b/Flasktest/views.py
@@ -3,13 +3,13 @@ from Flasktest.database import db_session
 from Flasktest.models import Entry
 from flask import Flask, request, session, g, redirect, url_for, \
 	abort, render_template, flash
-
+import socket
 
 
 @app.route('/')
 def show_entries():
   entries = Entry.query.all()
-  return render_template('show_entries.html', entries=entries)
+  return render_template('show_entries.html', entries=entries, hostname=socket.gethostname())
 
 @app.route('/add', methods=['POST'])
 def add_entry():


### PR DESCRIPTION
**What**

When testing out app scaling, it is useful to be able to identify which container is serving the application for any given request. This PR adds the docker container's hostname to the page title.

 * Import the python socket library inside views.py and set a pass a variable contianing the hostname when calling render_template
 * Update the layout.html template to display the hostname in addition to the title.

**How to review this PR**

I've created the PR to be reviewed in the following context:
* I need an application to display the container ID for use when testing app scaling


**Who should review this PR**

* Anyone in the core team.
