### PR TITLE
[#97630680] Tsuru healthcheck for zero-downtime deploys

### DIFF
--- a/Flasktest/views.py
+++ b/Flasktest/views.py
@@ -13,6 +13,11 @@ def show_entries():
     return render_template('show_entries.html', entries=entries, hostname=socket.gethostname())
 
 
+@app.route('/healthcheck')
+def healthcheck():
+    return "It's all cool\n", 200
+
+
 @app.route('/add', methods=['POST'])
 def add_entry():
     if not session.get('logged_in'):

--- a/tsuru.yaml
+++ b/tsuru.yaml
@@ -1,0 +1,2 @@
+healthcheck:
+  path: /healthcheck


### PR DESCRIPTION
#### Add /healthcheck endpoint

Which will return an HTTP 200 status if the app is running. This is very
simple, it intentionally does not confirm that the app can use PostgreSQL,
because that shouldn't be a dependency of starting or deploying.

HOWEVER: the app does currently fail to start if it doesn't have the
environment variables from Tsuru or it's unable to connect to PostgreSQL
when it first starts.

#### Add tsuru healthcheck config

Which will ensure that `GET /healthcheck` returns a 200 response before new
units are are added to the router. This means that application deploys and
restarts have zero downtime.

As noted in the preceding commit, the app will fail to start if it doesn't
have the environment variables or can't connect to PostgreSQL, so we need to
ensure those things are configured correctly for the demo otherwise the
deploy will also fail.

---

Related to https://github.gds/multicloudpaas/multicloudpaas.github.gds/pull/23

I'll separately add something to the demo script to demonstrate that this works.