### PR TITLE
[#99026674] Allow start without database connection or environment variables

### DIFF
--- a/Flasktest/__init__.py
+++ b/Flasktest/__init__.py
@@ -4,6 +4,7 @@ from Flasktest.database import db_session
 from flask import Flask
 from flask.ext.stats import Stats
 import os
+import logging
 
 # configuration
 DATABASE = '/tmp/flasktest.db'
@@ -15,6 +16,9 @@ PASSWORD = 'default'
 app = Flask(__name__)
 app.config.from_object(__name__)
 app.config.from_envvar('FLASKR_SETTINGS', silent=True)
+
+app.logger.addHandler(logging.StreamHandler())
+app.logger.setLevel(logging.INFO)
 
 import Flasktest.views
 

--- a/Flasktest/database.py
+++ b/Flasktest/database.py
@@ -3,11 +3,11 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 import os
 
-username = os.environ.get('PG_USER')
-password = os.environ.get('PG_PASSWORD')
-dbhost = os.environ.get('PG_HOST')
-dbport = os.environ.get('PG_PORT')
-db = os.environ.get('PG_DATABASE')
+username = os.environ.get('PG_USER', 'demo')
+password = os.environ.get('PG_PASSWORD', 'demo')
+dbhost = os.environ.get('PG_HOST', 'localhost')
+dbport = os.environ.get('PG_PORT', '5432')
+db = os.environ.get('PG_DATABASE', 'demo')
 
 uri = 'postgres://'+username+':'+password+'@'+dbhost+':'+dbport+'/'+db
 engine = create_engine(uri, convert_unicode=True, echo=True)

--- a/Flasktest/database.py
+++ b/Flasktest/database.py
@@ -1,6 +1,8 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.exc import OperationalError
+from flask import current_app as app
 import os
 
 username = os.environ.get('PG_USER', 'demo')
@@ -20,4 +22,7 @@ Base.query = db_session.query_property()
 
 def init_db():
     import Flasktest.models
-    Base.metadata.create_all(bind=engine)
+    try:
+        Base.metadata.create_all(bind=engine)
+    except OperationalError as e:
+        app.logger.error(e)

--- a/Flasktest/views.py
+++ b/Flasktest/views.py
@@ -15,7 +15,7 @@ def show_entries():
 
 @app.route('/healthcheck')
 def healthcheck():
-    return "It's all cool\n", 200
+    return "app is running\n", 200
 
 
 @app.route('/add', methods=['POST'])


### PR DESCRIPTION
#### Set defaults for pg_* environment variables

In order to allow the app to start and serve `/healthcheck` when the
environment variables have not been set. Otherwise it constantly fails
Tsuru's healthchecks when the app is:

- started (deployed) before `tsuru service-bind`
- restarted (automatically) after `tsuru service-unbind`

The latter has been extending the time our smoke tests take to run from
approx 50 seconds to 3 minutes because it keeps waiting for the healthcheck
to pass.

We should be able to start the app and bring it into service even if the
database connection isn't working.

#### Allow table creation to fail on start

In order to allow the app to start and serve `/healthcheck` when the
database is down or the correct environment variables have not been
configured. We shouldn't prevent a deployment or restart in these
circumstances, even though the app may not function completely.

In such a case an exception like the following will be logged to STDOUT and
picked up by Tsuru:

    2015-07-14 13:58:40 +0100 [web][e17e40337880]: (OperationalError) could not connect to server: Connection refused
    2015-07-14 13:58:40 +0100 [web][e17e40337880]:  Is the server running on host "localhost" (::1) and accepting
    2015-07-14 13:58:40 +0100 [web][e17e40337880]:  TCP/IP connections on port 5432?
    2015-07-14 13:58:40 +0100 [web][e17e40337880]: could not connect to server: Connection refused
    2015-07-14 13:58:40 +0100 [web][e17e40337880]:  Is the server running on host "localhost" (127.0.0.1) and accepting
    2015-07-14 13:58:40 +0100 [web][e17e40337880]:  TCP/IP connections on port 5432?
    2015-07-14 13:58:40 +0100 [web][e17e40337880]:  None None

If this is the first time that the application has been deployed and the
tables haven't been created before then it will require a restart, which in
the case of missing/incorrect environments will happen after `tsuru
service-bind`, in order to run `init_db()` again. This should be apparent
from the error pages produced the app though.

This, combined with the previous commit, will reduce the time that the smoke
tests take to run.