### PR TITLE
Reinstate init_db call broken in move to gunicorn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.DS_Store
 venv
 *.pyc

--- a/Flasktest/__init__.py
+++ b/Flasktest/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import with_statement
 from contextlib import closing
 from Flasktest.database import db_session
+from Flasktest.database import init_db
 from flask import Flask
 from flask.ext.stats import Stats
 import os
@@ -33,7 +34,12 @@ app.config['STATS_BASE_KEY'] = os.environ.get('STATS_BASE_KEY', "")
 
 # Initialise flask-metrics, only if connection setup
 if app.config['STATS_HOSTNAME'] != "":
-	stats = Stats().init_app(app)
+    stats = Stats().init_app(app)
+
+
+@app.before_first_request
+def init_stuff():
+    init_db()
 
 
 @app.teardown_request


### PR DESCRIPTION
__What__

In commit 8347bef0b8966aa461714c97f069838ae08a1b01, the move to gunicorn missed the fact that we
registered a database schema creation hook. Thus, when testing against an already existing application
the change worked perfectly. However, when the smoke tests in CI started a new app instance, the build
broke.

This commit moves the hook into the app declaration and now enables the db_init command to be called
when using gunicorn.

__How to test__

Create a new python app, deploy this branch to it, bind a postgresql instance to that app and check that the app behaves correctly (add a blog post, etc).

__Who can review__

Anyone but @dhilton
