### PR TITLE
Revert change to logging level to fix smoke tests. 

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn -b 0.0.0.0:$PORT -w 4 --timeout 120 --log-level=ERROR Flasktest:app
+web: gunicorn -b 0.0.0.0:$PORT -w 4 --timeout 120 --log-level=DEBUG Flasktest:app


### PR DESCRIPTION
__What___

In 764721afb7c695b8cce7f628bc32d12bd74f9c8a we decreased the logging level, to reduce noise. However, our smoketests check for the existence of a "special query" 404 entry in the logs, which never occurs if our log levels decrease.

This fixes this issue by increasing the log levels.

__How to test__

Check that when requesting a url that does not have a route, that the path gets written to the log output.

For example: 127.0.0.1:5000/my-special-query

